### PR TITLE
Ignore stderr while getting variables from make

### DIFF
--- a/bin/portupgrade
+++ b/bin/portupgrade
@@ -1465,7 +1465,7 @@ def get_pkgname(origin)
 
   cmdargs.concat(get_make_args(origin))
 
-  output = `cd #{portdir} && #{shelljoin(*cmdargs)} -V PKGNAME -V IGNORE -V NO_IGNORE -V ECHO_MSG 2>&1`.scan(/.*\n/)
+  output = `cd #{portdir} && #{shelljoin(*cmdargs)} -V PKGNAME -V IGNORE -V NO_IGNORE -V ECHO_MSG`.scan(/.*\n/)
 
   if output.size != 4
     warning_message "Makefile possibly broken: #{origin}:"


### PR DESCRIPTION
When getting contents of make variables (through make -V), portupgrade merges stderr with stdout (through 2>&1) for some reason, which leads to errors when some program called by the ports system writes something to stderr.

Example of the problem is here:
http://www.bsdportal.ru/viewtopic.php?p=148882#148759

I have no idea what exactly spews out 'No protocol specified' (I've only found this string in libipsec from the base system) in this case, but using stderr is erroneous anyway. I haven't looked, but there may be other places in pkgtools that require similar fix.
