### PR TITLE
Ignore stderr while getting variables from make

### DIFF
--- a/bin/portupgrade
+++ b/bin/portupgrade
@@ -859,7 +859,7 @@ def get_all_depends(origin, parents_list = nil)
 
     cmdargs.concat(get_make_args(origin))
 
-    `cd #{portdir} && #{shelljoin(*cmdargs)} -V #{depends_vars.join(' -V ')} 2>&1`.each_line do |line|
+    `cd #{portdir} && #{shelljoin(*cmdargs)} -V #{depends_vars.join(' -V ')}`.each_line do |line|
 	line.split(/\s+/).each do |dep|
 	  dep.sub!(/.*?:/,'')
 	  if dep.rindex(':') != nil


### PR DESCRIPTION
One more change to ignore stderr where it should be. Seems like the last one.
