### PR TITLE
update shell completions for portversion

### DIFF
--- a/misc/bash/complete.sample
+++ b/misc/bash/complete.sample
@@ -52,7 +52,7 @@ _pkg_func() {
     portversion)
 	case $cur in
 	-*)
-	    COMPREPLY=(-h -l -L -O -q -r -R -t -v -x)
+	    COMPREPLY=(-c -C -F -h -l -L -o -O -q -Q -r -R -t -v -x)
 	    ;;
 	*)
 	    COMPREPLY=( $(cd $dbdir && compgen -d $2) )

--- a/misc/zsh/_pkgtools
+++ b/misc/zsh/_pkgtools
@@ -280,12 +280,18 @@ _freebsd_pkgtools() {
     flags=(
       '-c[enable command output]'
       '-C[portupgrade flags for command output]'
+      '-F[display a package full name]'
+      '-h[show help]'
+      #'--ignore-moved[do not read MOVED file]'
       '-l[specify limit chars]:limit chars:'
       '-L[specify inverse limit chars]:inverse limit chars:'
+      '-o[display package origin]'
       '(-r -R)-O[omit sanity check]'
       '-q[do not read pkgtools.conf]'
+      '-Q[do not display status]'
       '(-O)-r[check recursively]'
       '(-O)-R[check upward recursively]'
+      '(-c -C -F --ignore-moved -l -L -O -o -R -r -x -Q)-t[compare the version]'
       '-v[be verbose]'
       '*-x[exclude packages]:exclude pattern:_bsd_pkg_pkgs'
     )


### PR DESCRIPTION
I added missing keys for portversion's completion (zsh, bash)
