### PR TITLE
Fixed TSort name clash

### DIFF
--- a/bin/pkgdb
+++ b/bin/pkgdb
@@ -441,7 +441,7 @@ def fix_db_phase2()
   # reconstruct all the +REQUIRED_BY files
   puts "Regenerating +REQUIRED_BY files" if $verbose
 
-  tsort = TSort.new
+  tsort = PkgTSort.new
   indep_pkgnames = []
 
   $pkgnames.each do |pkgname|

--- a/lib/pkgtools/pkgdb.rb
+++ b/lib/pkgtools/pkgdb.rb
@@ -955,7 +955,7 @@ class PkgDB
   end
 
   def tsort(pkgnames)
-    t = TSort.new
+    t = PkgTSort.new
 
     pkgnames.each do |pkgname|
       deps = pkgdep(pkgname) || []
@@ -975,7 +975,7 @@ class PkgDB
   end
 
   def tsort_build(pkgnames)
-    t = TSort.new
+    t = PkgTSort.new
 
     pkgnames.each do |pkgname|
       pkg = pkg(pkgname) or next

--- a/lib/pkgtools/pkgtsort.rb
+++ b/lib/pkgtools/pkgtsort.rb
@@ -32,7 +32,7 @@
 # Topological Sorter
 #
 
-class TSort
+class PkgTSort
   def initialize()
     @hints = Hash.new([])
   end
@@ -164,14 +164,14 @@ class TSort
 end
 
 if __FILE__ == $0
-  t = TSort.new
+  t = PkgTSort.new
   t.add(1, 2, 3).add(2, 4).add(3, 4).add(2, 3).add(1,3).add(6, 5).add(5, 1)
 
   p t.dump
   a = t.tsort { |cycle| puts "cycle found: " + cycle.join('-'); false }
   puts(*a)
 
-  t = TSort.new
+  t = PkgTSort.new
   t.add(1, 2, 3).add(2, 4).add(3, 4).add(2, 3).add(4,1).add(1,3).add(6, 5).add(5, 6)
 
   p t.dump

--- a/lib/pkgtools/portsdb.rb
+++ b/lib/pkgtools/portsdb.rb
@@ -887,7 +887,7 @@ class PortsDB
   end
 
   def sort(ports)
-    tsort = TSort.new
+    tsort = PkgTSort.new
 
     ports.each do |p|
       portinfo = port(p)

--- a/tests/test_pkgtsort.rb
+++ b/tests/test_pkgtsort.rb
@@ -6,14 +6,14 @@ require 'test/unit'
 
 require 'pkgtools/pkgtsort'
 
-class TestTSort < Test::Unit::TestCase
+class TestPkgTSort < Test::Unit::TestCase
   def test_s_new
-    assert_raises(ArgumentError) { TSort.new(1) }
-    assert_raises(ArgumentError) { TSort.new(nil) }
+    assert_raises(ArgumentError) { PkgTSort.new(1) }
+    assert_raises(ArgumentError) { PkgTSort.new(nil) }
   end
 
   def test_add
-    t = TSort.new
+    t = PkgTSort.new
 
     t.add(1, 2, 3)
     d = t.dump
@@ -35,7 +35,7 @@ class TestTSort < Test::Unit::TestCase
   end
 
   def test_delete
-    t = TSort.new
+    t = PkgTSort.new
 
     t.add(1, 2, 3)
     t.add(5, 1, 3, 4)
@@ -61,7 +61,7 @@ class TestTSort < Test::Unit::TestCase
   end
 
   def test_tsort
-    t = TSort.new
+    t = PkgTSort.new
 
     t.add(1, 2, 3)
     t.add(2, 4)


### PR DESCRIPTION
Without this it's not possible to run portupgrade's commands from bundler environment, or example:

/usr/src/puppet # bundle exec portversion

``` console
/usr/local/lib/ruby/site_ruby/1.9/pkgtools/pkgtsort.rb:35:in `<top (required)>': TSort is not a class (TypeError)
  from /usr/local/lib/ruby/site_ruby/1.9/pkgtools/pkgdb.rb:33:in `require'
  from /usr/local/lib/ruby/site_ruby/1.9/pkgtools/pkgdb.rb:33:in `<top (required)>'
  from /usr/local/lib/ruby/site_ruby/1.9/pkgtools/pkg.rb:2:in `require'
  from /usr/local/lib/ruby/site_ruby/1.9/pkgtools/pkg.rb:2:in `<top (required)>'
  from /usr/local/lib/ruby/site_ruby/1.9/pkgtools/pkgtools.rb:35:in `require'
  from /usr/local/lib/ruby/site_ruby/1.9/pkgtools/pkgtools.rb:35:in `<top (required)>'
  from /usr/local/lib/ruby/site_ruby/1.9/pkgtools.rb:1:in `require'
  from /usr/local/lib/ruby/site_ruby/1.9/pkgtools.rb:1:in `<top (required)>'
  from /usr/local/sbin/portversion:38:in `require'
  from /usr/local/sbin/portversion:38:in `<main>'
```

The reason is that there is a name clash between `TSort` class defined in `pkgtsort.rb` and the standard [TSort ruby module](http://ruby-doc.org/stdlib-1.9.3/libdoc/tsort/rdoc/TSort.html)

This patch removes the name clash by renaming `TSort` class to `PkgTSort`.
