### PR TITLE
Simplify step of building INDEX file.

### DIFF
--- a/lib/pkgtools/portsdb.rb
+++ b/lib/pkgtools/portsdb.rb
@@ -384,10 +384,6 @@ class PortsDB
     t.close
     tmp = t.path
 
-    t = Tempfile.new('INDEX.', abs_ports_dir)
-    t.close
-    tmpindex = t.path.split('/')[-1]
-
     if File.exist?(index_file)
       if !File.writable?(index_file)
 	STDERR.puts "index file #{index_file} not writable!"
@@ -405,7 +401,7 @@ class PortsDB
     if fetch
       system "cd #{abs_ports_dir} && make fetchindex && cp #{index_file} #{tmp}"
     else
-      system "cd #{abs_ports_dir} && make INDEXFILE=#{tmpindex} index && mv #{tmpindex} #{tmp}"
+      system "cd #{abs_ports_dir} && make INDEXDIR=#{File.dirname(tmp)} INDEXFILE=#{File.basename(tmp)} index"
     end
 
     if File.zero?(tmp)


### PR DESCRIPTION
Simplify step of building INDEX file by specifying `tmp` as direct output of `make index`.
