### PR TITLE
Add basic support for upgrading ports with flavors.

### DIFF
--- a/bin/portupgrade
+++ b/bin/portupgrade
@@ -1147,6 +1147,11 @@ def get_make_args(origin, pkgname = nil)
   else
     args = $make_args.split(' ')
   end
+
+  if flavor = origin[/@(.+)$/, 1]
+    args << 'FLAVOR=' + flavor
+  end
+
   quoted = 0
   n = 0
   is_quoted = false

--- a/lib/pkgtools/pkgdb.rb
+++ b/lib/pkgtools/pkgdb.rb
@@ -425,10 +425,20 @@ class PkgDB
       @installed_pkgs = []
       @installed_ports = []
       @db = {}
+
+      flavors = {}
+      pkg_flavors = xbackquote(PkgDB::command(:pkg), 'annotate', '-Sa',
+                               'flavor').split("\n")
+      pkg_flavors.each do |line|
+        pkg, flavor = line.sub(/: Tag: flavor Value: /, ':').split(':')
+        flavors[pkg] = flavor
+      end
+
       pkg_origins = xbackquote(PkgDB::command(:pkg), 'query', '%n-%v %o').split("\n")
       pkg_origins.each do |line|
         pkg, origin = line.split(' ')
         @installed_pkgs << pkg
+        origin << '@' + flavors[pkg] if flavors[pkg]
         add_origin(pkg, origin)
       end
       @installed_pkgs.freeze

--- a/lib/pkgtools/portsdb.rb
+++ b/lib/pkgtools/portsdb.rb
@@ -325,6 +325,7 @@ class PortsDB
   end
 
   def portdir(port)
+    port = port.sub(/@.*$/, '')
     File.join(ports_dir, port)
   end
 


### PR DESCRIPTION
This doesn't touch the fresh-install cases or the using-packages case, and those haven't been tested.  I believe the package case doesn't care much about origins; it just goes by package name, and the new install case can set flavors with `-m` like currently anyway.  My guess is that it won't affect them.

So, I _think_ this is a solid step forward by itself.  Upgrading installed ports via ports is presumably the 99.99% usecase for portupgrade, and this should make flavors work for that.